### PR TITLE
pulse: check for custom configuration file before Pulseaudio Droid

### DIFF
--- a/pulse/default.pa.droid
+++ b/pulse/default.pa.droid
@@ -37,14 +37,13 @@ load-module module-switch-on-port-available
 ### Switch when connected by default
 #load-module module-switch-on-connect skip_abstract=yes
 
-### Automatically load the Pulseaudio Droid and check for custom config file
+### Automatically check for custom config file and load the Pulseaudio Droid
 .ifexists module-droid-card.so
-load-module module-droid-card rate=48000 voice_virtual_stream=true
-.endif
-
-.ifexists /etc/pulse/arm_droid_card_custom.pa
-unload-module module-droid-card
-.include /etc/pulse/arm_droid_card_custom.pa
+  .ifexists /etc/pulse/arm_droid_card_custom.pa
+  .include /etc/pulse/arm_droid_card_custom.pa
+  .else
+  load-module module-droid-card rate=48000 voice_virtual_stream=true
+  .endif
 .endif
 
 .ifexists module-droid-hidl.so


### PR DESCRIPTION
some devices ( violet ) would segfault if Pulseaudio Droid is loaded, so we check and load custom configuration before trying the default one