### PR TITLE
pulse: Enable module-switch-on-connect

### DIFF
--- a/pulse/default.pa.droid
+++ b/pulse/default.pa.droid
@@ -35,7 +35,7 @@ load-module module-augment-properties
 load-module module-switch-on-port-available
 
 ### Switch when connected by default
-#load-module module-switch-on-connect skip_abstract=yes
+load-module module-switch-on-connect
 
 ### Automatically check for custom config file and load the Pulseaudio Droid
 .ifexists /etc/pulse/arm_droid_card_custom.pa


### PR DESCRIPTION
This fix switching to bluetooth devices on connect.